### PR TITLE
DOC-24: Exceptions to HTTP status codes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/HmppsDocumentManagementApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/HmppsDocumentManagementApiExceptionHandler.kt
@@ -1,14 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.config
 
+import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.ValidationException
+import org.apache.commons.lang3.StringUtils
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 @RestControllerAdvice
 class HmppsDocumentManagementApiExceptionHandler {
@@ -21,6 +25,42 @@ class HmppsDocumentManagementApiExceptionHandler {
         ErrorResponse(
           status = HttpStatus.FORBIDDEN.value(),
           userMessage = "Authentication problem. Check token and roles - ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+  fun handleMethodArgumentTypeMismatchException(e: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponse> {
+    log.info("Method argument type mismatch exception: {}", e.message)
+
+    val type = e.requiredType
+    val message = if (type.isEnum) {
+      "Parameter ${e.name} must be one of the following ${StringUtils.join(type.enumConstants, ", ")}"
+    } else {
+      "Parameter ${e.name} must be of type ${type.typeName}"
+    }
+
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          userMessage = "Validation failure: $message",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException::class)
+  fun handleNoBodyValidationException(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> {
+    log.info("Validation exception: Couldn't read request body: {}", e.message)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
+          userMessage = "Validation failure: Couldn't read request body: ${e.message}",
           developerMessage = e.message,
         ),
       )
@@ -49,6 +89,20 @@ class HmppsDocumentManagementApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Exception: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(EntityNotFoundException::class)
+  fun handleEntityNotFoundException(e: EntityNotFoundException): ResponseEntity<ErrorResponse> {
+    log.info("Entity not found exception: {}", e.message)
+    return ResponseEntity
+      .status(HttpStatus.NOT_FOUND)
+      .body(
+        ErrorResponse(
+          status = HttpStatus.NOT_FOUND.value(),
+          userMessage = "Not found: ${e.message}",
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentService.kt
@@ -42,6 +42,7 @@ class DocumentService(
     documentRequestContext: DocumentRequestContext,
   ): DocumentModel {
     // TODO: UUID check should include soft deleted documents
+    // TODO: Translate exception to 409 conflict
     require(documentRepository.findByDocumentUuid(documentUuid) == null) {
       "Document with UUID '$documentUuid' already exists in service"
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentSearchIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentSearchIntTest.kt
@@ -20,7 +20,7 @@ class DocumentSearchIntTest : IntegrationTestBase() {
   val metadata = JacksonUtil.toJsonNode("{ \"prisonNumber\": \"A1234BC\" }")
 
   @Test
-  fun unauthorised() {
+  fun `401 unauthorised`() {
     webTestClient.post()
       .uri("/documents/search")
       .bodyValue(DocumentSearchRequest(documentType, metadata))
@@ -29,7 +29,7 @@ class DocumentSearchIntTest : IntegrationTestBase() {
   }
 
   @Test
-  fun forbidden() {
+  fun `403 forbidden - no roles`() {
     webTestClient.post()
       .uri("/documents/search")
       .bodyValue(DocumentSearchRequest(documentType, metadata))
@@ -40,7 +40,19 @@ class DocumentSearchIntTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `bad request - missing service name header`() {
+  fun `403 forbidden - document writer`() {
+    webTestClient.post()
+      .uri("/documents/search")
+      .bodyValue(DocumentSearchRequest(documentType, metadata))
+      .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_WRITER)))
+      .headers(setAuthorisation())
+      .headers(setDocumentContext())
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  @Test
+  fun `400 bad request - missing service name header`() {
     val response = webTestClient.post()
       .uri("/documents/search")
       .bodyValue(DocumentSearchRequest(documentType, metadata))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentSearchIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentSearchIntTest.kt
@@ -45,7 +45,6 @@ class DocumentSearchIntTest : IntegrationTestBase() {
       .uri("/documents/search")
       .bodyValue(DocumentSearchRequest(documentType, metadata))
       .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_WRITER)))
-      .headers(setAuthorisation())
       .headers(setDocumentContext())
       .exchange()
       .expectStatus().isForbidden
@@ -67,6 +66,26 @@ class DocumentSearchIntTest : IntegrationTestBase() {
       assertThat(errorCode).isNull()
       assertThat(userMessage).isEqualTo("Exception: Service-Name header is required")
       assertThat(developerMessage).isEqualTo("Service-Name header is required")
+      assertThat(moreInfo).isNull()
+    }
+  }
+
+  @Test
+  fun `400 bad request - no body`() {
+    val response = webTestClient.post()
+      .uri("/documents/search")
+      .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_READER)))
+      .headers(setDocumentContext())
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody
+
+    with(response!!) {
+      assertThat(status).isEqualTo(400)
+      assertThat(errorCode).isNull()
+      assertThat(userMessage).isEqualTo("Validation failure: Couldn't read request body: Required request body is missing: public uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.DocumentSearchResult uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.resource.DocumentController.searchDocuments(uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.DocumentSearchRequest)")
+      assertThat(developerMessage).isEqualTo("Required request body is missing: public uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.DocumentSearchResult uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.resource.DocumentController.searchDocuments(uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.DocumentSearchRequest)")
       assertThat(moreInfo).isNull()
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/ReplaceDocumentMetadataIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/ReplaceDocumentMetadataIntTest.kt
@@ -78,6 +78,47 @@ class ReplaceDocumentMetadataIntTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `400 bad request - invalid document uuid`() {
+    val response = webTestClient.put()
+      .uri("/documents/INVALID/metadata")
+      .bodyValue(metadata)
+      .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_WRITER)))
+      .headers(setDocumentContext(serviceName, username))
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody
+
+    with(response!!) {
+      assertThat(status).isEqualTo(400)
+      assertThat(errorCode).isNull()
+      assertThat(userMessage).isEqualTo("Validation failure: Parameter documentUuid must be of type java.util.UUID")
+      assertThat(developerMessage).isEqualTo("Failed to convert value of type 'java.lang.String' to required type 'java.util.UUID'; Invalid UUID string: INVALID")
+      assertThat(moreInfo).isNull()
+    }
+  }
+
+  @Test
+  fun `400 bad request - no body`() {
+    val response = webTestClient.put()
+      .uri("/documents/$documentUuid/metadata")
+      .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_WRITER)))
+      .headers(setDocumentContext(serviceName, username))
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody
+
+    with(response!!) {
+      assertThat(status).isEqualTo(400)
+      assertThat(errorCode).isNull()
+      assertThat(userMessage).isEqualTo("Validation failure: Couldn't read request body: Required request body is missing: public uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.Document uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.resource.DocumentController.replaceDocumentMetadata(java.util.UUID,com.fasterxml.jackson.databind.JsonNode,jakarta.servlet.http.HttpServletRequest)")
+      assertThat(developerMessage).isEqualTo("Required request body is missing: public uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.Document uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.resource.DocumentController.replaceDocumentMetadata(java.util.UUID,com.fasterxml.jackson.databind.JsonNode,jakarta.servlet.http.HttpServletRequest)")
+      assertThat(moreInfo).isNull()
+    }
+  }
+
+  @Test
   fun `404 not found`() {
     val response = webTestClient.put()
       .uri("/documents/$documentUuid/metadata")


### PR DESCRIPTION
Covers:

- 400 - invalid request parameter
- 400 - missing request body
- 404 - entity not found