### PR TITLE
DOC-34: Document search validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/DocumentSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/DocumentSearchRequest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model
 
 import com.fasterxml.jackson.databind.JsonNode
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.AssertTrue
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
 
 @Schema(
@@ -27,4 +28,7 @@ data class DocumentSearchRequest(
     """,
   )
   val metadata: JsonNode,
-)
+) {
+  @AssertTrue(message = "Document type or metadata criteria must be supplied.")
+  fun isValid() = documentType != null || metadata.size() > 0
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/DocumentSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/DocumentSearchRequest.kt
@@ -2,15 +2,18 @@ package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model
 
 import com.fasterxml.jackson.databind.JsonNode
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.AssertTrue
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.validation.DocumentTypeOrMetadataCriteriaRequired
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.validation.NoNullOrEmptyStringMetadataValues
 
 @Schema(
-  description = "Describes the search parameters to use to filter documents.",
+  description = "Describes the search parameters to use to filter documents. Document type or metadata criteria " +
+    "must be supplied.",
 )
+@DocumentTypeOrMetadataCriteriaRequired
 data class DocumentSearchRequest(
   @Schema(
-    description = "The type or category of the document within HMPPS (optional)",
+    description = "The type or category of the document within HMPPS",
     example = "HMCTS_WARRANT",
   )
   val documentType: DocumentType?,
@@ -18,7 +21,8 @@ data class DocumentSearchRequest(
   @Schema(
     description = "JSON structured metadata to match with document metadata. Documents will match if their metadata " +
       "contains all the supplied properties and their values e.g. prisonCode = \"KMI\" AND prisonNumber = \"A1234BC\". " +
-      "Value matching is partial and case insensitive so court = \"ham magis\" will match \"Birmingham Magistrates\".",
+      "Value matching is partial and case insensitive so court = \"ham magis\" will match \"Birmingham Magistrates\". " +
+      "Property values must be strings and cannot be null or empty.",
     example =
     """
     {
@@ -27,8 +31,6 @@ data class DocumentSearchRequest(
     }
     """,
   )
-  val metadata: JsonNode,
-) {
-  @AssertTrue(message = "Document type or metadata criteria must be supplied.")
-  fun isValid() = documentType != null || metadata.size() > 0
-}
+  @field:NoNullOrEmptyStringMetadataValues
+  val metadata: JsonNode?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/DocumentSearchResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/DocumentSearchResult.kt
@@ -12,7 +12,8 @@ data class DocumentSearchResult(
   val request: DocumentSearchRequest,
 
   @Schema(
-    description = "The documents matching the supplied search parameters",
+    description = "The documents matching the supplied search parameters. Note that documents with types that require " +
+      "additional roles will have been filtered out of these results if the client does not have the required roles.",
   )
   val results: Collection<Document>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/validation/DocumentTypeOrMetadataCriteriaRequiredValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/validation/DocumentTypeOrMetadataCriteriaRequiredValidator.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.validation
+
+import com.fasterxml.jackson.databind.JsonNode
+import jakarta.validation.Constraint
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import jakarta.validation.Payload
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.DocumentSearchRequest
+import kotlin.reflect.KClass
+
+class DocumentTypeOrMetadataCriteriaRequiredValidator : ConstraintValidator<DocumentTypeOrMetadataCriteriaRequired, DocumentSearchRequest> {
+  override fun isValid(value: DocumentSearchRequest?, context: ConstraintValidatorContext): Boolean {
+    if (value == null) {
+      return false
+    }
+
+    if (value.documentType != null) {
+      return true
+    }
+
+    if (value.metadata.isNotNullWithAtLeastOneProperty()) {
+      return true
+    }
+
+    return false
+  }
+
+  private fun JsonNode?.isNotNullWithAtLeastOneProperty() =
+    this != null && this.isObject && this.size() > 0
+}
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [DocumentTypeOrMetadataCriteriaRequiredValidator::class])
+annotation class DocumentTypeOrMetadataCriteriaRequired(
+  val message: String = "Document type or metadata criteria must be supplied.",
+  val groups: Array<KClass<*>> = [],
+  val payload: Array<KClass<out Payload>> = [],
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/validation/DocumentTypeOrMetadataCriteriaRequiredValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/validation/DocumentTypeOrMetadataCriteriaRequiredValidator.kt
@@ -9,11 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.DocumentSea
 import kotlin.reflect.KClass
 
 class DocumentTypeOrMetadataCriteriaRequiredValidator : ConstraintValidator<DocumentTypeOrMetadataCriteriaRequired, DocumentSearchRequest> {
-  override fun isValid(value: DocumentSearchRequest?, context: ConstraintValidatorContext): Boolean {
-    if (value == null) {
-      return false
-    }
-
+  override fun isValid(value: DocumentSearchRequest, context: ConstraintValidatorContext): Boolean {
     if (value.documentType != null) {
       return true
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/validation/NoNullOrEmptyStringMetadataValuesValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/validation/NoNullOrEmptyStringMetadataValuesValidator.kt
@@ -22,8 +22,8 @@ class NoNullOrEmptyStringMetadataValuesValidator : ConstraintValidator<NoNullOrE
     return true
   }
 
-  private fun JsonNode?.isNullOrEmpty() =
-    this == null || !isTextual || asText().isEmpty()
+  private fun JsonNode.isNullOrEmpty() =
+    !isTextual || asText().isEmpty()
 }
 
 @Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/validation/NoNullOrEmptyStringMetadataValuesValidator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/validation/NoNullOrEmptyStringMetadataValuesValidator.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.validation
+
+import com.fasterxml.jackson.databind.JsonNode
+import jakarta.validation.Constraint
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import jakarta.validation.Payload
+import kotlin.reflect.KClass
+
+class NoNullOrEmptyStringMetadataValuesValidator : ConstraintValidator<NoNullOrEmptyStringMetadataValues, JsonNode> {
+  override fun isValid(value: JsonNode?, context: ConstraintValidatorContext): Boolean {
+    if (value == null || !value.isObject) {
+      return true
+    }
+
+    for (fieldName in value.fieldNames()) {
+      if (value[fieldName].isNullOrEmpty()) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  private fun JsonNode?.isNullOrEmpty() =
+    this == null || !isTextual || asText().isEmpty()
+}
+
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [NoNullOrEmptyStringMetadataValuesValidator::class])
+annotation class NoNullOrEmptyStringMetadataValues(
+  val message: String = "Metadata property values must be non null or empty strings.",
+  val groups: Array<KClass<*>> = [],
+  val payload: Array<KClass<out Payload>> = [],
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentController.kt
@@ -328,11 +328,13 @@ class DocumentController(
   @ResponseStatus(HttpStatus.OK)
   @PostMapping("/search")
   @Operation(
-    summary = "Search for documents with matching metadata and optionally document type",
-    description = "Uses the supplied metadata and optional document type to filter and return documents. " +
-      "Documents will match if they are of the supplied type (optional) and/or their metadata contains all the supplied " +
+    summary = "Search for documents with matching document type and/or metadata criteria",
+    description = "Uses the supplied document type and metadata criteria to filter and return documents. " +
+      "Documents will match if they are of the supplied type and/or their metadata contains all the supplied " +
       "properties and their values e.g. prisonCode = \"KMI\" AND prisonNumber = \"A1234BC\". Value matching is partial " +
-      "and case insensitive so court = \"ham magis\" will match \"Birmingham Magistrates\".",
+      "and case insensitive so court = \"ham magis\" will match \"Birmingham Magistrates\". Document type or metadata " +
+      "criteria must be supplied. Note that documents with types that require additional roles will be filtered out of " +
+      "the search results if the client does not have the required roles.",
   )
   @ApiResponses(
     value = [

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentSearchSpecification.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentSearchSpecification.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.Docum
 
 @Component
 class DocumentSearchSpecification {
-  fun prisonCodeEquals(documentType: DocumentType?) =
+  fun documentTypeEquals(documentType: DocumentType?) =
     if (documentType == null) {
       Specification<Document> { _, _, cb -> cb.conjunction() }
     } else {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchService.kt
@@ -25,7 +25,7 @@ class DocumentSearchService(
 
     var spec = documentSearchSpecification.documentTypeEquals(request.documentType)
 
-    request.metadata.fields().forEach {
+    request.metadata?.fields()?.forEach {
       spec = spec.and(documentSearchSpecification.metadataContains(it.key, it.value.asText()))
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchService.kt
@@ -30,6 +30,7 @@ class DocumentSearchService(
     }
 
     val results = documentRepository.findAll(spec)
+      .filter { authorisedDocumentTypes.contains(it.documentType) }
 
     return DocumentSearchResult(
       request,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchService.kt
@@ -23,7 +23,7 @@ class DocumentSearchService(
       }
     }
 
-    var spec = documentSearchSpecification.prisonCodeEquals(request.documentType)
+    var spec = documentSearchSpecification.documentTypeEquals(request.documentType)
 
     request.metadata.fields().forEach {
       spec = spec.and(documentSearchSpecification.metadataContains(it.key, it.value.asText()))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/DocumentSearchRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/model/DocumentSearchRequestTest.kt
@@ -1,0 +1,85 @@
+package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model
+
+import io.hypersistence.utils.hibernate.type.json.internal.JacksonUtil
+import jakarta.validation.ConstraintViolation
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
+
+class DocumentSearchRequestTest {
+  private val validator: Validator = Validation.buildDefaultValidatorFactory().validator
+
+  @Test
+  fun `valid request - document type specified null metadata`() {
+    val request = DocumentSearchRequest(DocumentType.HMCTS_WARRANT, null)
+    assertThat(validator.validate(request)).isEmpty()
+  }
+
+  @Test
+  fun `valid request - document type specified empty metadata`() {
+    val request = DocumentSearchRequest(DocumentType.HMCTS_WARRANT, JacksonUtil.toJsonNode("{}"))
+    assertThat(validator.validate(request)).isEmpty()
+  }
+
+  @Test
+  fun `valid request - document type specified non object metadata`() {
+    val request = DocumentSearchRequest(DocumentType.HMCTS_WARRANT, JacksonUtil.toJsonNode("[ \"test\" ]"))
+    assertThat(validator.validate(request)).isEmpty()
+  }
+
+  @Test
+  fun `valid request - null document type valid metadata`() {
+    val request = DocumentSearchRequest(null, JacksonUtil.toJsonNode("{ \"prisonNumber\": \"A1234BC\" }"))
+    assertThat(validator.validate(request)).isEmpty()
+  }
+
+  @Test
+  fun `document type or metadata criteria must be supplied - null document type and metadata`() {
+    val request = DocumentSearchRequest(null, null)
+    validator.validate(request).assertSingleValidationError("", "Document type or metadata criteria must be supplied.")
+  }
+
+  @Test
+  fun `document type or metadata criteria must be supplied - null document type and empty metadata`() {
+    val request = DocumentSearchRequest(null, JacksonUtil.toJsonNode("{}"))
+    validator.validate(request).assertSingleValidationError("", "Document type or metadata criteria must be supplied.")
+  }
+
+  @Test
+  fun `document type or metadata criteria must be supplied - null document type and non object metadata`() {
+    val request = DocumentSearchRequest(null, JacksonUtil.toJsonNode("[ \"test\" ]"))
+    validator.validate(request).assertSingleValidationError("", "Document type or metadata criteria must be supplied.")
+  }
+
+  @Test
+  fun `metadata property values must be non null or empty strings - null value`() {
+    val request = DocumentSearchRequest(null, JacksonUtil.toJsonNode("{ \"prisonNumber\": null }"))
+    validator.validate(request).assertSingleValidationError("metadata", "Metadata property values must be non null or empty strings.")
+  }
+
+  @Test
+  fun `metadata property values must be non null or empty strings - empty value`() {
+    val request = DocumentSearchRequest(null, JacksonUtil.toJsonNode("{ \"prisonNumber\": \"\" }"))
+    validator.validate(request).assertSingleValidationError("metadata", "Metadata property values must be non null or empty strings.")
+  }
+
+  @Test
+  fun `metadata property values must be non null or empty strings - numerical value`() {
+    val request = DocumentSearchRequest(null, JacksonUtil.toJsonNode("{ \"prisonNumber\": 1234 }"))
+    validator.validate(request).assertSingleValidationError("metadata", "Metadata property values must be non null or empty strings.")
+  }
+
+  @Test
+  fun `metadata property values must be non null or empty strings - decimal value`() {
+    val request = DocumentSearchRequest(null, JacksonUtil.toJsonNode("{ \"prisonNumber\": 12.34 }"))
+    validator.validate(request).assertSingleValidationError("metadata", "Metadata property values must be non null or empty strings.")
+  }
+
+  private fun MutableSet<ConstraintViolation<DocumentSearchRequest>>.assertSingleValidationError(propertyName: String, message: String) =
+    with(single()) {
+      assertThat(propertyPath.toString()).isEqualTo(propertyName)
+      assertThat(message).isEqualTo(message)
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentSearchIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentSearchIntTest.kt
@@ -90,6 +90,27 @@ class DocumentSearchIntTest : IntegrationTestBase() {
     }
   }
 
+  @Test
+  fun `400 bad request - document type or metadata criteria must be supplied`() {
+    val response = webTestClient.post()
+      .uri("/documents/search")
+      .bodyValue(DocumentSearchRequest(null, JacksonUtil.toJsonNode("{}")))
+      .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_READER)))
+      .headers(setDocumentContext())
+      .exchange()
+      .expectStatus().isBadRequest
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody
+
+    with(response!!) {
+      assertThat(status).isEqualTo(400)
+      assertThat(errorCode).isNull()
+      assertThat(userMessage).isEqualTo("Validation failure: Document type or metadata criteria must be supplied.")
+      assertThat(developerMessage).isEqualTo("Document type or metadata criteria must be supplied.")
+      assertThat(moreInfo).isNull()
+    }
+  }
+
   @Sql("classpath:test_data/document-search.sql")
   @Test
   fun `response contains search request`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchServiceTest.kt
@@ -43,7 +43,7 @@ class DocumentSearchServiceTest {
 
     service.searchDocuments(DocumentSearchRequest(documentType, metadata), DocumentType.entries)
 
-    verify(documentSearchSpecification).prisonCodeEquals(documentType)
+    verify(documentSearchSpecification).documentTypeEquals(documentType)
     verify(documentSearchSpecification).metadataContains("prisonNumber", "A1234BC")
     verifyNoMoreInteractions(documentSearchSpecification)
 
@@ -58,7 +58,7 @@ class DocumentSearchServiceTest {
 
     service.searchDocuments(DocumentSearchRequest(documentType, metadata), DocumentType.entries)
 
-    verify(documentSearchSpecification).prisonCodeEquals(null)
+    verify(documentSearchSpecification).documentTypeEquals(null)
     verify(documentSearchSpecification).metadataContains("prisonNumber", "A1234BC")
     verifyNoMoreInteractions(documentSearchSpecification)
 
@@ -73,7 +73,7 @@ class DocumentSearchServiceTest {
 
     service.searchDocuments(DocumentSearchRequest(documentType, metadata), DocumentType.entries)
 
-    verify(documentSearchSpecification).prisonCodeEquals(documentType)
+    verify(documentSearchSpecification).documentTypeEquals(documentType)
     verify(documentSearchSpecification).metadataContains("prisonCode", "KPI")
     verify(documentSearchSpecification).metadataContains("prisonNumber", "A1234BC")
     verifyNoMoreInteractions(documentSearchSpecification)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchServiceTest.kt
@@ -37,6 +37,20 @@ class DocumentSearchServiceTest {
   )
 
   @Test
+  fun `search by document type only`() {
+    val documentType = DocumentType.HMCTS_WARRANT
+    val metadata = null
+
+    service.searchDocuments(DocumentSearchRequest(documentType, metadata), DocumentType.entries)
+
+    verify(documentSearchSpecification).documentTypeEquals(documentType)
+    verifyNoMoreInteractions(documentSearchSpecification)
+
+    verify(documentRepository).findAll(any<Specification<Document>>())
+    verifyNoMoreInteractions(documentRepository)
+  }
+
+  @Test
   fun `search by document type and metadata property`() {
     val documentType = DocumentType.HMCTS_WARRANT
     val metadata = JacksonUtil.toJsonNode("{ \"prisonNumber\": \"A1234BC\" }")
@@ -76,6 +90,20 @@ class DocumentSearchServiceTest {
     verify(documentSearchSpecification).documentTypeEquals(documentType)
     verify(documentSearchSpecification).metadataContains("prisonCode", "KPI")
     verify(documentSearchSpecification).metadataContains("prisonNumber", "A1234BC")
+    verifyNoMoreInteractions(documentSearchSpecification)
+
+    verify(documentRepository).findAll(any<Specification<Document>>())
+    verifyNoMoreInteractions(documentRepository)
+  }
+
+  @Test
+  fun `ignores non object metadata`() {
+    val documentType = null
+    val metadata = JacksonUtil.toJsonNode("[ \"test\" ]")
+
+    service.searchDocuments(DocumentSearchRequest(documentType, metadata), DocumentType.entries)
+
+    verify(documentSearchSpecification).documentTypeEquals(null)
     verifyNoMoreInteractions(documentSearchSpecification)
 
     verify(documentRepository).findAll(any<Specification<Document>>())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchServiceTest.kt
@@ -24,7 +24,7 @@ class DocumentSearchServiceTest {
 
   private val service = DocumentSearchService(documentRepository, documentSearchSpecification)
 
-  private val document = Document(
+  private val warrantDocument = Document(
     documentType = DocumentType.HMCTS_WARRANT,
     filename = "warrant_for_remand",
     fileExtension = "pdf",
@@ -34,6 +34,18 @@ class DocumentSearchServiceTest {
     metadata = JacksonUtil.toJsonNode("{ \"prisonCode\": \"KPI\", \"prisonNumber\": \"A1234BC\" }"),
     createdByServiceName = "Remand and Sentencing",
     createdByUsername = "CREATED_BY_USER",
+  )
+
+  private val sarDocument = Document(
+    documentType = DocumentType.SUBJECT_ACCESS_REQUEST_REPORT,
+    filename = "subject_access_request_report",
+    fileExtension = "pdf",
+    fileSize = 63621,
+    fileHash = "0e0396b7a0e931762c167abb7da85398",
+    mimeType = "application/pdf",
+    metadata = JacksonUtil.toJsonNode("{ \"sarCaseReference\": \"SAR-1234\", \"prisonCode\": \"KPI\", \"prisonNumber\": \"A1234BC\" }"),
+    createdByServiceName = "Manage Subject Access Requests",
+    createdByUsername = "SAR_USER",
   )
 
   @Test
@@ -116,10 +128,23 @@ class DocumentSearchServiceTest {
     val metadata = JacksonUtil.toJsonNode("{ \"prisonNumber\": \"A1234BC\" }")
     val request = DocumentSearchRequest(documentType, metadata)
 
-    whenever(documentRepository.findAll(any<Specification<Document>>())).thenReturn(listOf(document))
+    whenever(documentRepository.findAll(any<Specification<Document>>())).thenReturn(listOf(warrantDocument))
 
     val response = service.searchDocuments(request, DocumentType.entries)
 
-    assertThat(response).isEqualTo(DocumentSearchResult(request, listOf(document).toModels()))
+    assertThat(response).isEqualTo(DocumentSearchResult(request, listOf(warrantDocument).toModels()))
+  }
+
+  @Test
+  fun `returns results filtered by authorised document types`() {
+    val documentType = DocumentType.HMCTS_WARRANT
+    val metadata = JacksonUtil.toJsonNode("{ \"prisonNumber\": \"A1234BC\" }")
+    val request = DocumentSearchRequest(documentType, metadata)
+
+    whenever(documentRepository.findAll(any<Specification<Document>>())).thenReturn(listOf(warrantDocument, sarDocument))
+
+    val response = service.searchDocuments(request, listOf(DocumentType.HMCTS_WARRANT))
+
+    assertThat(response).isEqualTo(DocumentSearchResult(request, listOf(warrantDocument).toModels()))
   }
 }


### PR DESCRIPTION
The following validation is applied to document search requests:

- Document type or metadata criteria must be supplied
- Metadata property values must be non null or empty strings

In addition, document types that the client does not have permission to view, e.g. Subject Access Request Reports, will be filtered out of the results.