### PR TITLE
CVSL-1568 Add CVL Exclusion zone document types

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/enumeration/DocumentType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/enumeration/DocumentType.kt
@@ -13,7 +13,7 @@ enum class DocumentType(
     description = "Subject Access Request Report",
     additionalRoles = setOf(ROLE_DOCUMENT_TYPE_SAR),
   ),
-  CVL_DOCS(
-    description = "Offender Licence documents created and managed by CVL (create and vary a licence create-and-vary-a-licence-api)",
+  EXCLUSION_ZONE_MAP(
+    description = "Exclusion zone maps used for exclusion zone condition on offender licence",
   ),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/enumeration/DocumentType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/enumeration/DocumentType.kt
@@ -13,13 +13,7 @@ enum class DocumentType(
     description = "Subject Access Request Report",
     additionalRoles = setOf(ROLE_DOCUMENT_TYPE_SAR),
   ),
-  HMPPS_LICENCE_EXCLUSION_ZONE_MAP(
-    description = "Map image for the exclusion zone condition added to the licence",
-  ),
-  HMPPS_LICENCE_EXCLUSION_ZONE_MAP_ORIG_DATA(
-    description = "Original data for the exclusion zone condition added to the licence",
-  ),
-  HMPPS_LICENCE_EXCLUSION_ZONE_MAP_THUMBNAIL(
-    description = "Original data for the exclusion zone condition added to the licence",
+  HHMPPS_CVL_DOCS(
+    description = "Offender Licence documents created and managed by CVL (create and vary a licence create-and-vary-a-licence-api)",
   ),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/enumeration/DocumentType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/enumeration/DocumentType.kt
@@ -13,4 +13,13 @@ enum class DocumentType(
     description = "Subject Access Request Report",
     additionalRoles = setOf(ROLE_DOCUMENT_TYPE_SAR),
   ),
+  HMPPS_LICENCE_EXCLUSION_ZONE_MAP(
+    description = "Map image for the exclusion zone condition added to the licence",
+  ),
+  HMPPS_LICENCE_EXCLUSION_ZONE_MAP_ORIG_DATA(
+    description = "Original data for the exclusion zone condition added to the licence",
+  ),
+  HMPPS_LICENCE_EXCLUSION_ZONE_MAP_THUMBNAIL(
+    description = "Original data for the exclusion zone condition added to the licence",
+  ),
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/enumeration/DocumentType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/enumeration/DocumentType.kt
@@ -13,7 +13,7 @@ enum class DocumentType(
     description = "Subject Access Request Report",
     additionalRoles = setOf(ROLE_DOCUMENT_TYPE_SAR),
   ),
-  HHMPPS_CVL_DOCS(
+  CVL_DOCS(
     description = "Offender Licence documents created and managed by CVL (create and vary a licence create-and-vary-a-licence-api)",
   ),
 }


### PR DESCRIPTION
CVSL-1568 create and vary licence API stores maps for exclusion zone conditions. This PR adds the types for these.