### PR TITLE
DOC-56: Remove transactions to prevent connection pool saturation under load

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.13.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.14.0"
   kotlin("plugin.spring") version "1.9.22"
   kotlin("plugin.jpa") version "1.9.22"
   jacoco

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   db:
-    image: postgres:15
+    image: postgres:16
     networks:
       - hmpps
     container_name: document-management-db

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/DocumentTypeAuthorisationConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/DocumentTypeAuthorisationConfiguration.kt
@@ -54,11 +54,23 @@ class DocumentTypeAuthorisationInterceptor(
 
   private fun HttpServletRequest.documentUuidFromPathVariable() =
     pathVariables()["documentUuid"]
-      ?.let { try { UUID.fromString(it.toString()) } catch (e: IllegalArgumentException) { null } }
+      ?.let {
+        try {
+          UUID.fromString(it.toString())
+        } catch (e: IllegalArgumentException) {
+          null
+        }
+      }
 
   private fun HttpServletRequest.documentTypeFromPathVariable() =
     pathVariables()["documentType"]
-      ?.let { try { DocumentType.valueOf(it.toString()) } catch (e: IllegalArgumentException) { null } }
+      ?.let {
+        try {
+          DocumentType.valueOf(it.toString())
+        } catch (e: IllegalArgumentException) {
+          null
+        }
+      }
 
   private fun HttpServletRequest.documentTypeFromUuidOrTypePathVariable() =
     documentUuidFromPathVariable()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/HmppsDocumentManagementApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/HmppsDocumentManagementApiExceptionHandler.kt
@@ -114,8 +114,8 @@ class HmppsDocumentManagementApiExceptionHandler {
 
   @ExceptionHandler(MethodArgumentNotValidException::class)
   fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse>? {
-    log.debug("Method argument not valid exception: {}", e.message)
-    val errors = e.bindingResult.allErrors.map { it.defaultMessage }.joinToString(", ")
+    log.info("Method argument not valid exception: {}", e.message)
+    val errors = e.bindingResult.allErrors.joinToString(", ") { it.defaultMessage }
     return ResponseEntity
       .status(BAD_REQUEST)
       .body(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/OpenApiConfiguration.kt
@@ -67,7 +67,11 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
           },
         )
 
-        val roles = try { (preAuthExp.getValue(evalContext) as List<*>).filterIsInstance<String>() } catch (e: SpelEvaluationException) { emptyList() }
+        val roles = try {
+          (preAuthExp.getValue(evalContext) as List<*>).filterIsInstance<String>()
+        } catch (e: SpelEvaluationException) {
+          emptyList()
+        }
         if (roles.isNotEmpty()) {
           operation.description = "${operation.description ?: ""}\n\n" +
             "Requires one of the following roles:\n" +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.service
 import org.springframework.data.domain.PageRequest
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.config.DocumentRequestContext
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.entity.toModels
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentSearchService.kt
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.repository.Docume
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.resource.DocumentSearchSpecification
 
 @Service
-@Transactional(readOnly = true)
 class DocumentSearchService(
   private val documentRepository: DocumentRepository,
   private val documentSearchSpecification: DocumentSearchSpecification,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentService.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.Document as
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.DocumentFile as DocumentFileModel
 
 @Service
-@Transactional
 class DocumentService(
   private val documentRepository: DocumentRepository,
   private val documentFileService: DocumentFileService,

--- a/src/main/resources/migration/common/V5__exclusion_zone_map_document_type.sql
+++ b/src/main/resources/migration/common/V5__exclusion_zone_map_document_type.sql
@@ -1,0 +1,1 @@
+INSERT INTO document_type VALUES ('EXCLUSION_ZONE_MAP', 'Exclusion zone maps used for exclusion zone condition on offender licence');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/integration/container/PostgresContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/integration/container/PostgresContainer.kt
@@ -17,7 +17,7 @@ object PostgresContainer {
 
     val logConsumer = Slf4jLogConsumer(log).withPrefix("postgresql")
 
-    return PostgreSQLContainer<Nothing>("postgres:15").apply {
+    return PostgreSQLContainer<Nothing>("postgres:16").apply {
       withEnv("HOSTNAME_EXTERNAL", "localhost")
       withDatabaseName("document-management")
       withUsername("document-management")


### PR DESCRIPTION
Under heavy load, the service could throw exceptions indicating it could not connect to the database due to no available connection threads in the pool. This was found during performance testing.

There was a transaction used when uploading the document used to roll back the creation of the document record if the document file failed to upload to S3. This reserved the database connection while the file was uploading to S3, making running out of connections more likely.

This PR replaces the transaction with a deletion of the document record if an exception is thrown while uploading the document to S3.