### PR TITLE
Update hmpps gradle spring boot plugin to version 6.0.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.7"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.8"
   kotlin("plugin.spring") version "2.0.21"
   kotlin("plugin.jpa") version "2.0.21"
   jacoco

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/integration/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/integration/TestConstants.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration
+
+object TestConstants {
+  const val INVALID_UUID = "INVALID"
+  const val INVALID_DOCUMENT_TYPE = "INVALID"
+  const val INVALID_UUID_EXCEPTION_MESSAGE_TEMPLATE =
+    "Method parameter 'documentUuid': Failed to convert value of type 'java.lang.String' to required type 'java.util.UUID'; Invalid UUID string: %s"
+  const val INVALID_DOC_TYPE_EXCEPTION_MESSAGE_TEMPLATE =
+    "Method parameter 'documentType': Failed to convert value of type 'java.lang.String' to required type 'uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType'; Failed to convert from type [java.lang.String] to type [@org.springframework.web.bind.annotation.PathVariable @io.swagger.v3.oas.annotations.Parameter uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType] for value [%s]"
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DeleteDocumentIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DeleteDocumentIntTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.config.ErrorRespo
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.EventType
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.TestConstants
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.assertIsDocumentWithNoMetadataHistoryId1
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.Document
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.repository.DocumentRepository
@@ -104,7 +105,7 @@ class DeleteDocumentIntTest : IntegrationTestBase() {
   @Test
   fun `400 bad request - invalid document uuid`() {
     val response = webTestClient.delete()
-      .uri("/documents/INVALID")
+      .uri("/documents/${TestConstants.INVALID_UUID}")
       .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_WRITER)))
       .headers(setDocumentContext(serviceName, activeCaseLoadId, username))
       .exchange()
@@ -116,7 +117,7 @@ class DeleteDocumentIntTest : IntegrationTestBase() {
       assertThat(status).isEqualTo(400)
       assertThat(errorCode).isNull()
       assertThat(userMessage).isEqualTo("Validation failure: Parameter documentUuid must be of type java.util.UUID")
-      assertThat(developerMessage).isEqualTo("Failed to convert value of type 'java.lang.String' to required type 'java.util.UUID'; Invalid UUID string: INVALID")
+      assertThat(developerMessage).isEqualTo(String.format(TestConstants.INVALID_UUID_EXCEPTION_MESSAGE_TEMPLATE, TestConstants.INVALID_UUID))
       assertThat(moreInfo).isNull()
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DownloadDocumentIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DownloadDocumentIntTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.config.ErrorRespo
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.EventType
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.TestConstants
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.assertIsDocumentWithNoMetadataHistoryId1
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.Document
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.service.AuditService
@@ -101,7 +102,7 @@ class DownloadDocumentIntTest : IntegrationTestBase() {
   @Test
   fun `400 bad request - invalid document uuid`() {
     val response = webTestClient.get()
-      .uri("/documents/INVALID/file")
+      .uri("/documents/${TestConstants.INVALID_UUID}/file")
       .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_READER)))
       .headers(setDocumentContext(serviceName, activeCaseLoadId, username))
       .exchange()
@@ -113,7 +114,7 @@ class DownloadDocumentIntTest : IntegrationTestBase() {
       assertThat(status).isEqualTo(400)
       assertThat(errorCode).isNull()
       assertThat(userMessage).isEqualTo("Validation failure: Parameter documentUuid must be of type java.util.UUID")
-      assertThat(developerMessage).isEqualTo("Failed to convert value of type 'java.lang.String' to required type 'java.util.UUID'; Invalid UUID string: INVALID")
+      assertThat(developerMessage).isEqualTo(String.format(TestConstants.INVALID_UUID_EXCEPTION_MESSAGE_TEMPLATE, TestConstants.INVALID_UUID))
       assertThat(moreInfo).isNull()
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/GetDocumentIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/GetDocumentIntTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.config.ErrorRespo
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.EventType
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.TestConstants
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.assertIsDocumentWithNoMetadataHistoryId1
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.service.AuditService
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.service.whenLocalDateTime
@@ -99,7 +100,7 @@ class GetDocumentIntTest : IntegrationTestBase() {
   @Test
   fun `400 bad request - invalid document uuid`() {
     val response = webTestClient.get()
-      .uri("/documents/INVALID")
+      .uri("/documents/${TestConstants.INVALID_UUID}")
       .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_READER)))
       .headers(setDocumentContext(serviceName, activeCaseLoadId, username))
       .exchange()
@@ -111,7 +112,7 @@ class GetDocumentIntTest : IntegrationTestBase() {
       assertThat(status).isEqualTo(400)
       assertThat(errorCode).isNull()
       assertThat(userMessage).isEqualTo("Validation failure: Parameter documentUuid must be of type java.util.UUID")
-      assertThat(developerMessage).isEqualTo("Failed to convert value of type 'java.lang.String' to required type 'java.util.UUID'; Invalid UUID string: INVALID")
+      assertThat(developerMessage).isEqualTo(String.format(TestConstants.INVALID_UUID_EXCEPTION_MESSAGE_TEMPLATE, TestConstants.INVALID_UUID))
       assertThat(moreInfo).isNull()
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/ReplaceDocumentMetadataIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/ReplaceDocumentMetadataIntTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.config.ErrorRespo
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.EventType
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.TestConstants
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.assertIsDocumentWithNoMetadataHistoryId1
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.model.event.DocumentMetadataReplacedEvent
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.repository.DocumentRepository
@@ -114,7 +115,7 @@ class ReplaceDocumentMetadataIntTest : IntegrationTestBase() {
   @Test
   fun `400 bad request - invalid document uuid`() {
     val response = webTestClient.put()
-      .uri("/documents/INVALID/metadata")
+      .uri("/documents/${TestConstants.INVALID_UUID}/metadata")
       .bodyValue(metadata)
       .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_WRITER)))
       .headers(setDocumentContext(serviceName, activeCaseLoadId, username))
@@ -127,7 +128,7 @@ class ReplaceDocumentMetadataIntTest : IntegrationTestBase() {
       assertThat(status).isEqualTo(400)
       assertThat(errorCode).isNull()
       assertThat(userMessage).isEqualTo("Validation failure: Parameter documentUuid must be of type java.util.UUID")
-      assertThat(developerMessage).isEqualTo("Failed to convert value of type 'java.lang.String' to required type 'java.util.UUID'; Invalid UUID string: INVALID")
+      assertThat(developerMessage).isEqualTo(String.format(TestConstants.INVALID_UUID_EXCEPTION_MESSAGE_TEMPLATE, TestConstants.INVALID_UUID))
       assertThat(moreInfo).isNull()
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/UploadDocumentIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/UploadDocumentIntTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.config.ErrorRespo
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.EventType
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.integration.TestConstants
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.repository.DocumentRepository
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.service.AuditService
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.service.DocumentFileService
@@ -115,7 +116,7 @@ class UploadDocumentIntTest : IntegrationTestBase() {
   @Test
   fun `400 bad request - invalid document type`() {
     val response = webTestClient.post()
-      .uri("/documents/INVALID/${UUID.randomUUID()}")
+      .uri("/documents/${TestConstants.INVALID_DOCUMENT_TYPE}/${UUID.randomUUID()}")
       .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_WRITER)))
       .headers(setDocumentContext(serviceName, activeCaseLoadId, username))
       .exchange()
@@ -127,7 +128,7 @@ class UploadDocumentIntTest : IntegrationTestBase() {
       assertThat(status).isEqualTo(400)
       assertThat(errorCode).isNull()
       assertThat(userMessage).isEqualTo("Validation failure: Parameter documentType must be one of the following ${StringUtils.join(DocumentType.entries.toTypedArray(), ", ")}")
-      assertThat(developerMessage).isEqualTo("Failed to convert value of type 'java.lang.String' to required type 'uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType'; Failed to convert from type [java.lang.String] to type [@org.springframework.web.bind.annotation.PathVariable @io.swagger.v3.oas.annotations.Parameter uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType] for value [INVALID]")
+      assertThat(developerMessage).isEqualTo(String.format(TestConstants.INVALID_DOC_TYPE_EXCEPTION_MESSAGE_TEMPLATE, TestConstants.INVALID_DOCUMENT_TYPE))
       assertThat(moreInfo).isNull()
     }
   }
@@ -135,7 +136,7 @@ class UploadDocumentIntTest : IntegrationTestBase() {
   @Test
   fun `400 bad request - invalid document uuid`() {
     val response = webTestClient.post()
-      .uri("/documents/${DocumentType.HMCTS_WARRANT}/INVALID")
+      .uri("/documents/${DocumentType.HMCTS_WARRANT}/${TestConstants.INVALID_UUID}")
       .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_WRITER)))
       .headers(setDocumentContext(serviceName, activeCaseLoadId, username))
       .exchange()
@@ -147,7 +148,7 @@ class UploadDocumentIntTest : IntegrationTestBase() {
       assertThat(status).isEqualTo(400)
       assertThat(errorCode).isNull()
       assertThat(userMessage).isEqualTo("Validation failure: Parameter documentUuid must be of type java.util.UUID")
-      assertThat(developerMessage).isEqualTo("Failed to convert value of type 'java.lang.String' to required type 'java.util.UUID'; Invalid UUID string: INVALID")
+      assertThat(developerMessage).isEqualTo(String.format(TestConstants.INVALID_UUID_EXCEPTION_MESSAGE_TEMPLATE, TestConstants.INVALID_UUID))
       assertThat(moreInfo).isNull()
     }
   }


### PR DESCRIPTION
 - [x] HMPPS gradle-spring-boot plugin updated to version 6.0.8. This results in a version bump to 6.3.4 for `spring-security-web` resolving CVE-2024-38821 reported by trivy [here](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-document-management-api/809/workflows/26fef463-8576-4897-8e1f-70c245b6b215/jobs/2130/steps).
 - [x] Updated integration tests that failed due to a change in the error message produced by the `MethodArgumentTypeMismatchException` class introduced in `spring-web` 6.1.14.