### PR TITLE
Add config-gated document hard-purge endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/DocumentMaintenanceConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/DocumentMaintenanceConfiguration.kt
@@ -4,5 +4,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@EnableConfigurationProperties(DocumentHashingProperties::class)
-class DocumentHashingConfiguration
+@EnableConfigurationProperties(
+  DocumentHashingProperties::class,
+  DocumentPurgeProperties::class,
+)
+class DocumentMaintenanceConfiguration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/DocumentPurgeProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/config/DocumentPurgeProperties.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
+import java.time.LocalDate
+
+@ConfigurationProperties(prefix = "document.purge")
+data class DocumentPurgeProperties(
+  val batchSize: Int = 250,
+  val before: LocalDate = LocalDate.parse("1970-01-01"),
+  val documentTypes: Set<DocumentType> = emptySet(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/repository/DocumentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/repository/DocumentRepository.kt
@@ -5,10 +5,12 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.entity.Document
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
@@ -47,6 +49,38 @@ interface DocumentRepository :
     afterUuid: UUID,
     pageable: Pageable,
   ): List<Document>
+
+  @Query(
+    value = "SELECT * FROM document WHERE document_type IN (:documentTypes) AND created_time < :before AND document_id > :afterId ORDER BY document_id LIMIT :batchSize",
+    nativeQuery = true,
+  )
+  fun findPurgeableBatch(
+    documentTypes: Collection<String>,
+    before: LocalDateTime,
+    afterId: Long,
+    batchSize: Int,
+  ): List<Document>
+
+  @Modifying
+  @Query(
+    value = "UPDATE document SET duplicate_of = NULL WHERE duplicate_of IN (:uuids)",
+    nativeQuery = true,
+  )
+  fun clearDuplicateOfPointersTo(uuids: Collection<UUID>)
+
+  @Modifying
+  @Query(
+    value = "DELETE FROM document_metadata_history WHERE document_id IN (:documentIds)",
+    nativeQuery = true,
+  )
+  fun deleteMetadataHistoryByDocumentIds(documentIds: Collection<Long>)
+
+  @Modifying
+  @Query(
+    value = "DELETE FROM document WHERE document_id IN (:documentIds)",
+    nativeQuery = true,
+  )
+  fun deleteByDocumentIds(documentIds: Collection<Long>)
 }
 
 fun DocumentRepository.findByDocumentUuidOrThrowNotFound(documentUuid: UUID) = this.findByDocumentUuid(documentUuid) ?: throw EntityNotFoundException("Document with UUID '$documentUuid' not found.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentMaintenanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentMaintenanceController.kt
@@ -7,27 +7,51 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.config.DocumentPurgeProperties
 import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.service.DocumentFileHashBackfillService
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.service.DocumentPurgeService
 
 @RestController
 @RequestMapping(value = ["/maintenance"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @Hidden
 class DocumentMaintenanceController(
   private val fileHashBackfillService: DocumentFileHashBackfillService,
+  private val documentPurgeService: DocumentPurgeService,
+  private val purge: DocumentPurgeProperties,
 ) {
   @PostMapping("/file-hash-backfill")
   @PreAuthorize("hasRole('$ROLE_DOCUMENT_ADMIN')")
   fun backfillFileHashes(
     @RequestParam(name = "confirm", required = true) confirm: String,
   ): Map<String, String> {
-    require(confirm == CONFIRM_TOKEN) {
-      "Pass confirm=$CONFIRM_TOKEN to run the file hash backfill"
+    require(confirm == BACKFILL_CONFIRM_TOKEN) {
+      "Pass confirm=$BACKFILL_CONFIRM_TOKEN to run the file hash backfill"
     }
     val started = fileHashBackfillService.run()
     return mapOf("status" to if (started) "complete" else "already-running")
   }
 
+  @PostMapping("/purge")
+  @PreAuthorize("hasRole('$ROLE_DOCUMENT_ADMIN')")
+  fun purgeDocuments(
+    @RequestParam(name = "confirm", required = true) confirm: String,
+  ): Map<String, Any> {
+    require(confirm == PURGE_CONFIRM_TOKEN) {
+      "Pass confirm=$PURGE_CONFIRM_TOKEN to run the document purge"
+    }
+    require(purge.documentTypes.isNotEmpty()) {
+      "No purge document types configured; set document.purge.document-types and redeploy"
+    }
+    val result = documentPurgeService.purge(purge.documentTypes, purge.before)
+    return mapOf(
+      "started" to result.started,
+      "purgedCount" to result.purgedCount,
+      "s3FailureCount" to result.s3FailureCount,
+    )
+  }
+
   private companion object {
-    const val CONFIRM_TOKEN = "BACKFILL"
+    const val BACKFILL_CONFIRM_TOKEN = "BACKFILL"
+    const val PURGE_CONFIRM_TOKEN = "PURGE"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentFileService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentFileService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
@@ -44,8 +45,17 @@ class DocumentFileService(
 
     try {
       return s3Client.getObject(request)
-    } catch (e: NoSuchKeyException) {
+    } catch (_: NoSuchKeyException) {
       throw DocumentFileNotFoundException(documentUuid)
     }
+  }
+
+  fun deleteDocumentFile(documentUuid: UUID, documentType: DocumentType) {
+    val request = DeleteObjectRequest.builder()
+      .bucket(getBucketName(documentType))
+      .key(documentUuid.toString())
+      .build()
+
+    s3Client.deleteObject(request)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentPurgeBatchExecutor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentPurgeBatchExecutor.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.service
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.repository.DocumentRepository
+import java.util.UUID
+
+@Component
+class DocumentPurgeBatchExecutor(
+  private val documentRepository: DocumentRepository,
+) {
+  @Transactional
+  fun purgeBatch(documentIds: List<Long>, documentUuids: List<UUID>) {
+    documentRepository.clearDuplicateOfPointersTo(documentUuids)
+    documentRepository.deleteMetadataHistoryByDocumentIds(documentIds)
+    documentRepository.deleteByDocumentIds(documentIds)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentPurgeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentPurgeService.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.repository.DocumentRepository
+import java.time.LocalDate
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Service
+class DocumentPurgeService(
+  private val documentRepository: DocumentRepository,
+  private val documentFileService: DocumentFileService,
+  private val purgeBatchExecutor: DocumentPurgeBatchExecutor,
+  @Value("\${document.purge.batch-size:100}") private val batchSize: Int,
+) {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  private val running = AtomicBoolean(false)
+
+  fun purge(documentTypes: Set<DocumentType>, before: LocalDate): DocumentPurgeResult {
+    if (!running.compareAndSet(false, true)) {
+      log.info("Document purge already running on this pod; ignoring request")
+      return DocumentPurgeResult(started = false)
+    }
+
+    val cutoff = before.atStartOfDay()
+    var afterId = 0L
+    var purgedCount = 0
+    var s3FailureCount = 0
+
+    try {
+      log.info("Document purge starting: types={}, before={}, batchSize={}", documentTypes, cutoff, batchSize)
+
+      while (true) {
+        val batch = documentRepository.findPurgeableBatch(
+          documentTypes = documentTypes.map { it.name },
+          before = cutoff,
+          afterId = afterId,
+          batchSize = batchSize,
+        )
+        if (batch.isEmpty()) break
+
+        val batchIds = batch.map { it.documentId }
+        val batchUuids = batch.map { it.documentUuid }
+        val batchTypes = batch.map { it.documentUuid to it.documentType }
+
+        purgeBatchExecutor.purgeBatch(batchIds, batchUuids)
+
+        batchTypes.forEach { (uuid, documentType) ->
+          runCatching { documentFileService.deleteDocumentFile(uuid, documentType) }
+            .onFailure {
+              s3FailureCount++
+              log.warn("Failed to delete S3 object for document {} ({}); orphaned object may remain", uuid, documentType, it)
+            }
+        }
+
+        afterId = batch.last().documentId
+        purgedCount += batch.size
+        log.info("Document purge progress: {} documents processed so far", purgedCount)
+      }
+
+      log.info("Document purge complete: purgedCount={}, s3FailureCount={}", purgedCount, s3FailureCount)
+    } finally {
+      running.set(false)
+    }
+
+    return DocumentPurgeResult(started = true, purgedCount = purgedCount, s3FailureCount = s3FailureCount)
+  }
+}
+
+data class DocumentPurgeResult(
+  val started: Boolean,
+  val purgedCount: Int = 0,
+  val s3FailureCount: Int = 0,
+)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -100,3 +100,7 @@ document:
   canonical:
     authoritative-service-names:
       - "Remand and Sentencing"
+  purge:
+    batch-size: 250
+    before: "2026-06-01"
+    document-types: [HMCTS_WARRANT, PRISON_COURT_REGISTER]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentPurgeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/service/DocumentPurgeServiceTest.kt
@@ -1,0 +1,187 @@
+package uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import tools.jackson.databind.ObjectMapper
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.entity.Document
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.enumeration.DocumentType
+import uk.gov.justice.digital.hmpps.hmppsdocumentmanagementapi.repository.DocumentRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class DocumentPurgeServiceTest {
+  private val documentRepository: DocumentRepository = mock()
+  private val documentFileService: DocumentFileService = mock()
+  private val purgeBatchExecutor: DocumentPurgeBatchExecutor = mock()
+
+  private val service = DocumentPurgeService(
+    documentRepository,
+    documentFileService,
+    purgeBatchExecutor,
+    batchSize = 2,
+  )
+
+  private val cutoffDate = LocalDate.of(2024, 1, 1)
+  private val targetTypes = setOf(DocumentType.HMCTS_WARRANT, DocumentType.PRISON_COURT_REGISTER)
+
+  @BeforeEach
+  fun setUp() {
+    whenever(documentRepository.findPurgeableBatch(any(), any(), any(), any())).thenReturn(emptyList())
+  }
+
+  @Test
+  fun `does nothing when no documents match`() {
+    val result = service.purge(targetTypes, cutoffDate)
+
+    assertThat(result.started).isTrue()
+    assertThat(result.purgedCount).isEqualTo(0)
+    assertThat(result.s3FailureCount).isEqualTo(0)
+    verify(purgeBatchExecutor, never()).purgeBatch(any(), any())
+    verify(documentFileService, never()).deleteDocumentFile(any(), any())
+  }
+
+  @Test
+  fun `passes cutoff as start-of-day and types as enum names to repository`() {
+    val cutoffCaptor = argumentCaptor<LocalDateTime>()
+    val typesCaptor = argumentCaptor<Collection<String>>()
+    whenever(documentRepository.findPurgeableBatch(typesCaptor.capture(), cutoffCaptor.capture(), any(), any()))
+      .thenReturn(emptyList())
+
+    service.purge(targetTypes, cutoffDate)
+
+    assertThat(cutoffCaptor.firstValue).isEqualTo(cutoffDate.atStartOfDay())
+    assertThat(typesCaptor.firstValue).containsExactlyInAnyOrder("HMCTS_WARRANT", "PRISON_COURT_REGISTER")
+  }
+
+  @Test
+  fun `purges a single batch - DB executor first, then S3 for each document`() {
+    val doc1 = makeDocument(documentId = 1L, documentType = DocumentType.HMCTS_WARRANT)
+    val doc2 = makeDocument(documentId = 2L, documentType = DocumentType.PRISON_COURT_REGISTER)
+    whenever(documentRepository.findPurgeableBatch(any(), any(), any(), any()))
+      .thenReturn(listOf(doc1, doc2))
+      .thenReturn(emptyList())
+
+    val result = service.purge(targetTypes, cutoffDate)
+
+    assertThat(result.purgedCount).isEqualTo(2)
+    assertThat(result.s3FailureCount).isEqualTo(0)
+
+    val idsCaptor = argumentCaptor<List<Long>>()
+    val uuidsCaptor = argumentCaptor<List<UUID>>()
+    verify(purgeBatchExecutor).purgeBatch(idsCaptor.capture(), uuidsCaptor.capture())
+    assertThat(idsCaptor.firstValue).containsExactly(1L, 2L)
+    assertThat(uuidsCaptor.firstValue).containsExactly(doc1.documentUuid, doc2.documentUuid)
+
+    verify(documentFileService).deleteDocumentFile(doc1.documentUuid, DocumentType.HMCTS_WARRANT)
+    verify(documentFileService).deleteDocumentFile(doc2.documentUuid, DocumentType.PRISON_COURT_REGISTER)
+  }
+
+  @Test
+  fun `advances cursor between batches using the last document_id`() {
+    val batch1Doc1 = makeDocument(documentId = 1L)
+    val batch1Doc2 = makeDocument(documentId = 2L)
+    val batch2Doc1 = makeDocument(documentId = 5L)
+
+    val afterIdCaptor = argumentCaptor<Long>()
+    whenever(documentRepository.findPurgeableBatch(any(), any(), afterIdCaptor.capture(), any()))
+      .thenReturn(listOf(batch1Doc1, batch1Doc2))
+      .thenReturn(listOf(batch2Doc1))
+      .thenReturn(emptyList())
+
+    val result = service.purge(targetTypes, cutoffDate)
+
+    assertThat(result.purgedCount).isEqualTo(3)
+    // 0 for the first lookup, then the last id of each non-empty batch
+    assertThat(afterIdCaptor.allValues).containsExactly(0L, 2L, 5L)
+  }
+
+  @Test
+  fun `counts S3 failures and continues - DB purge still completes for the batch`() {
+    val doc1 = makeDocument(documentId = 1L)
+    val doc2 = makeDocument(documentId = 2L)
+    whenever(documentRepository.findPurgeableBatch(any(), any(), any(), any()))
+      .thenReturn(listOf(doc1, doc2))
+      .thenReturn(emptyList())
+
+    doThrow(RuntimeException("S3 unavailable"))
+      .whenever(documentFileService).deleteDocumentFile(eq(doc1.documentUuid), any())
+
+    val result = service.purge(targetTypes, cutoffDate)
+
+    assertThat(result.purgedCount).isEqualTo(2)
+    assertThat(result.s3FailureCount).isEqualTo(1)
+
+    verify(purgeBatchExecutor).purgeBatch(listOf(1L, 2L), listOf(doc1.documentUuid, doc2.documentUuid))
+    verify(documentFileService).deleteDocumentFile(doc2.documentUuid, doc2.documentType)
+  }
+
+  @Test
+  fun `returns not-started when a purge is already running on this pod`() {
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+
+    // The first purge blocks inside the repository lookup while holding the running flag.
+    whenever(documentRepository.findPurgeableBatch(any(), any(), any(), any())).thenAnswer {
+      entered.countDown()
+      release.await()
+      emptyList<Document>()
+    }
+
+    val pool = Executors.newSingleThreadExecutor()
+    try {
+      val first = pool.submit<DocumentPurgeResult> { service.purge(targetTypes, cutoffDate) }
+
+      assertThat(entered.await(5, TimeUnit.SECONDS)).isTrue()
+      val second = service.purge(targetTypes, cutoffDate)
+      assertThat(second.started).isFalse()
+
+      release.countDown()
+      assertThat(first.get(5, TimeUnit.SECONDS).started).isTrue()
+    } finally {
+      release.countDown()
+      pool.shutdownNow()
+    }
+  }
+
+  @Test
+  fun `releases the running flag after an exception so a later run can proceed`() {
+    whenever(documentRepository.findPurgeableBatch(any(), any(), any(), any()))
+      .thenThrow(RuntimeException("DB error"))
+
+    runCatching { service.purge(targetTypes, cutoffDate) }
+
+    whenever(documentRepository.findPurgeableBatch(any(), any(), any(), any())).thenReturn(emptyList())
+    assertThat(service.purge(targetTypes, cutoffDate).started).isTrue()
+  }
+
+  private fun makeDocument(
+    documentId: Long = 0L,
+    documentType: DocumentType = DocumentType.HMCTS_WARRANT,
+  ) = Document(
+    documentId = documentId,
+    documentUuid = UUID.randomUUID(),
+    documentType = documentType,
+    filename = "test",
+    fileExtension = "pdf",
+    fileSize = 1024,
+    fileHash = "",
+    mimeType = "application/pdf",
+    metadata = ObjectMapper().readTree("{}"),
+    createdTime = LocalDateTime.now().minusYears(1),
+    createdByServiceName = "test-service",
+    createdByUsername = "TEST_USER",
+  )
+}


### PR DESCRIPTION
Adds a maintenance endpoint that permanently removes documents of configured types created before a configured cutoff date, deleting the document rows, their metadata history, and the backing S3 objects. This gives a controlled, batched way to clear down old documents instead of ad-hoc deletion.

The scope is deliberately not a request parameter. The endpoint takes only a confirm token; the document types and cutoff date are read from configuration (document.purge.*), so changing what the purge deletes requires a reviewed config change and a deploy rather than something a caller picks at runtime. For an irreversible mass-delete that runtime freedom was the main risk, so it is gone.

Defaults are inert: no document types and a 1970 cutoff, so an unconfigured or un-armed environment is a no-op and the endpoint rejects the call when no types are set. Scope is set per environment, since the appropriate cutoff differs between them, and binds as a typed list via @ConfigurationProperties so a bad type name fails at startup rather than at purge time.

Execution safety:
- Admin only (ROLE_DOCUMENT_ADMIN) plus the confirm token.
- Batched with a document_id cursor, and a per-pod running flag so two triggers cannot overlap.
- DB rows are deleted in a transaction first, then S3 objects best-effort, so a partial failure orphans a blob rather than leaving a row pointing at nothing. S3 failures are counted and logged, not fatal.
- duplicate_of pointers to purged documents are cleared first, keeping the dedup graph consistent and the deletes FK-safe.