### PR TITLE
Add optional inline Content-Disposition for PDF downloads

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentController.kt
@@ -138,9 +138,9 @@ class DocumentController(
   ): ResponseEntity<InputStreamResource> {
     val documentFile = documentService.getDocumentFile(documentUuid, request.documentRequestContext())
     val inputStreamResource = InputStreamResource(documentFile.inputStream)
-    // Only PDFs may be served inline. The == is a deliberate safety gate, not an assumption that the
-    // store only holds PDFs: serving arbitrary stored content inline (e.g. text/html, image/svg+xml)
-    // would let a browser render it in-context, which is a stored-XSS vector. Widen with care.
+    // We currently only want PDFs served inline on request (the store may hold many other types).
+    // Be cautious widening this: serving arbitrary stored content inline (e.g. text/html,
+    // image/svg+xml) lets a browser render it in-context, which is a stored-XSS vector.
     val renderInline = inline && documentFile.mimeType == MediaType.APPLICATION_PDF_VALUE
     val disposition = if (renderInline) "inline" else "attachment"
     return ResponseEntity.ok()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DocumentController.kt
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -126,14 +127,26 @@ class DocumentController(
       required = true,
     )
     documentUuid: UUID,
+    @RequestParam(name = "inline", required = false, defaultValue = "false")
+    @Parameter(
+      description = "When true, serves the file with Content-Disposition: inline so it renders in the " +
+        "browser instead of downloading. Only honoured for PDFs; any other type falls back to attachment. " +
+        "Defaults to false.",
+    )
+    inline: Boolean,
     request: HttpServletRequest,
   ): ResponseEntity<InputStreamResource> {
     val documentFile = documentService.getDocumentFile(documentUuid, request.documentRequestContext())
     val inputStreamResource = InputStreamResource(documentFile.inputStream)
+    // Only PDFs may be served inline. The == is a deliberate safety gate, not an assumption that the
+    // store only holds PDFs: serving arbitrary stored content inline (e.g. text/html, image/svg+xml)
+    // would let a browser render it in-context, which is a stored-XSS vector. Widen with care.
+    val renderInline = inline && documentFile.mimeType == MediaType.APPLICATION_PDF_VALUE
+    val disposition = if (renderInline) "inline" else "attachment"
     return ResponseEntity.ok()
       .contentType(MediaType.parseMediaType(documentFile.mimeType))
       .contentLength(documentFile.fileSize)
-      .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"${documentFile.filename}\"")
+      .header(HttpHeaders.CONTENT_DISPOSITION, "$disposition; filename=\"${documentFile.filename}\"")
       .body(inputStreamResource)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DownloadDocumentIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdocumentmanagementapi/resource/DownloadDocumentIntTest.kt
@@ -178,6 +178,57 @@ class DownloadDocumentIntTest : IntegrationTestBase() {
 
   @Sql("classpath:test_data/document-with-no-metadata-history-id-1.sql")
   @Test
+  fun `download document inline renders pdf inline`() {
+    val fileBytes = putDocumentInS3(documentUuid, "test_data/warrant-for-remand.pdf", S3BucketName.DOCUMENT_MANAGEMENT.value)
+
+    val response = webTestClient.downloadDocument(
+      documentUuid,
+      MediaType.APPLICATION_PDF,
+      20688,
+      "warrant_for_remand.pdf",
+      inline = true,
+      expectedDisposition = "inline",
+    )
+
+    assertThat(response.responseBody).isEqualTo(fileBytes)
+  }
+
+  @Sql("classpath:test_data/document-with-no-metadata-history-id-1.sql")
+  @Test
+  fun `download document inline false uses attachment`() {
+    val fileBytes = putDocumentInS3(documentUuid, "test_data/warrant-for-remand.pdf", S3BucketName.DOCUMENT_MANAGEMENT.value)
+
+    val response = webTestClient.downloadDocument(
+      documentUuid,
+      MediaType.APPLICATION_PDF,
+      20688,
+      "warrant_for_remand.pdf",
+      inline = false,
+      expectedDisposition = "attachment",
+    )
+
+    assertThat(response.responseBody).isEqualTo(fileBytes)
+  }
+
+  @Sql("classpath:test_data/document-with-non-pdf-mime-id-1.sql")
+  @Test
+  fun `download document inline is ignored for non-pdf and falls back to attachment`() {
+    val fileBytes = putDocumentInS3(documentUuid, "test_data/warrant-for-remand.pdf", S3BucketName.DOCUMENT_MANAGEMENT.value)
+
+    val response = webTestClient.downloadDocument(
+      documentUuid,
+      MediaType.TEXT_HTML,
+      20688,
+      "preview_me.html",
+      inline = true,
+      expectedDisposition = "attachment",
+    )
+
+    assertThat(response.responseBody).isEqualTo(fileBytes)
+  }
+
+  @Sql("classpath:test_data/document-with-no-metadata-history-id-1.sql")
+  @Test
   fun `audits event`() {
     putDocumentInS3(documentUuid, "test_data/warrant-for-remand.pdf", S3BucketName.DOCUMENT_MANAGEMENT.value)
 
@@ -239,15 +290,21 @@ class DownloadDocumentIntTest : IntegrationTestBase() {
     contentType: MediaType,
     contentLength: Long,
     filename: String,
+    inline: Boolean? = null,
+    expectedDisposition: String = "attachment",
   ) = get()
-    .uri("/documents/$documentUuid/file")
+    .uri { builder ->
+      builder.path("/documents/$documentUuid/file")
+      if (inline != null) builder.queryParam("inline", inline)
+      builder.build()
+    }
     .headers(setAuthorisation(roles = listOf(ROLE_DOCUMENT_READER)))
     .headers(setDocumentContext(serviceName, activeCaseLoadId, username))
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(contentType)
     .expectHeader().contentLength(contentLength)
-    .expectHeader().contentDisposition(ContentDisposition.parse("attachment; filename=\"$filename\""))
+    .expectHeader().contentDisposition(ContentDisposition.parse("$expectedDisposition; filename=\"$filename\""))
     .expectBody(ByteArray::class.java)
     .returnResult()
 }

--- a/src/test/resources/test_data/document-with-non-pdf-mime-id-1.sql
+++ b/src/test/resources/test_data/document-with-non-pdf-mime-id-1.sql
@@ -1,0 +1,30 @@
+INSERT INTO document
+(
+    document_id,
+    document_uuid,
+    document_type,
+    filename,
+    file_extension,
+    file_size,
+    file_hash,
+    mime_type,
+    metadata,
+    created_time,
+    created_by_service_name,
+    created_by_username
+)
+VALUES
+(
+    1,
+    'f73a0f91-2957-4224-b477-714370c04d37',
+    'HMCTS_WARRANT',
+    'preview_me',
+    'html',
+    20688,
+    'd58e3582afa99040e27b92b13c8f2280',
+    'text/html',
+    JSON '{ "prisonCode": "KMI", "prisonNumber": "A1234BC" }',
+    NOW(),
+    'Remand and Sentencing',
+    'CREATED_BY_USER'
+);


### PR DESCRIPTION
The file download endpoint always returned Content-Disposition: attachment, forcing a download. Add an optional `inline` query param (default false) so callers can request in-browser rendering, keeping the existing attachment behaviour unchanged for everyone who omits it.

Inline is gated to application/pdf only. Serving arbitrary stored content inline (e.g. text/html, image/svg+xml) would let a browser render it in-context, which is a stored-XSS vector, so any non-PDF type silently falls back to attachment even when inline=true is requested.

Extends DownloadDocumentIntTest with cases for inline PDF rendering, explicit inline=false, and the non-PDF fallback (new text/html fixture).